### PR TITLE
Fix crash on java.lang.IllegalStateException: Reply already submitted

### DIFF
--- a/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
+++ b/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
@@ -131,7 +131,11 @@ public class ContactsServicePlugin implements MethodCallHandler {
     }
 
     protected void onPostExecute(ArrayList<HashMap> result) {
-      getContactResult.success(result);
+      try{
+        getContactResult.success(result);
+      } catch(IllegalStateException e){
+        e.printStackTrace();
+      }
     }
   }
 


### PR DESCRIPTION
Hey! my first PR ever! (ignore this line :D)

This PR fixes crash issue when contact is returned by the pluggin and seconds later, the stack trace below is thrown.
 
W/System.err(20136): java.lang.IllegalStateException: Reply already submitted
W/System.err(20136):    at io.flutter.view.FlutterNativeView$1.reply(FlutterNativeView.java:146)
W/System.err(20136):    at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:194)
W/System.err(20136):    at flutter.plugins.contactsservice.contactsservice.ContactsServicePlugin$GetContactsTask.onPostExecute(ContactsServicePlugin.java:135)
W/System.err(20136):    at flutter.plugins.contactsservice.contactsservice.ContactsServicePlugin$GetContactsTask.onPostExecute(ContactsServicePlugin.java:115)
W/System.err(20136):    at android.os.AsyncTask.finish(AsyncTask.java:667)
W/System.err(20136):    at android.os.AsyncTask.-wrap1(AsyncTask.java)
W/System.err(20136):    at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:684)
W/System.err(20136):    at android.os.Handler.dispatchMessage(Handler.java:102)
W/System.err(20136):    at android.os.Looper.loop(Looper.java:154)
W/System.err(20136):    at android.app.ActivityThread.main(ActivityThread.java:6816)
W/System.err(20136):    at java.lang.reflect.Method.invoke(Native Method)
W/System.err(20136):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1563)
W/System.err(20136):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1451)