### PR TITLE
Fix for issue #21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.9] - October 10th, 2018
+* Fix an issue when fetching contacts on Android
+
 ## [0.0.8] - August 16th, 2018
 * Fix an issue with phones being added to emails on Android
 * Update plugin for dart 2

--- a/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
+++ b/android/src/main/java/flutter/plugins/contactsservice/contactsservice/ContactsServicePlugin.java
@@ -39,8 +39,6 @@ public class ContactsServicePlugin implements MethodCallHandler {
 
   private final ContentResolver contentResolver;
 
-  private Result getContactResult;
-
   public static void registerWith(Registrar registrar) {
     final MethodChannel channel = new MethodChannel(registrar.messenger(), "github.com/clovisnicolas/flutter_contacts");
     channel.setMethodCallHandler(new ContactsServicePlugin(registrar.context().getContentResolver()));
@@ -50,8 +48,7 @@ public class ContactsServicePlugin implements MethodCallHandler {
   public void onMethodCall(MethodCall call, Result result) {
     switch(call.method){
       case "getContacts":
-        getContactResult = result;
-        this.getContacts((String)call.arguments);
+        this.getContacts((String)call.arguments, result);
         break;
       case "addContact":
         Contact c = Contact.fromMap((HashMap)call.arguments);
@@ -108,13 +105,19 @@ public class ContactsServicePlugin implements MethodCallHandler {
 
 
   @TargetApi(Build.VERSION_CODES.ECLAIR)
-  private void getContacts(String query) {
-    new GetContactsTask().execute(new String[] {query});
+  private void getContacts(String query, Result result) {
+    new GetContactsTask(result).execute(new String[] {query});
   }
 
   @TargetApi(Build.VERSION_CODES.CUPCAKE)
   private class GetContactsTask extends AsyncTask<String, Void, ArrayList<HashMap>> {
 
+    private Result getContactResult;
+	
+	public GetContactsTask(Result result){
+		this.getContactResult = result;
+	}	
+  
     @TargetApi(Build.VERSION_CODES.ECLAIR)
     protected ArrayList<HashMap> doInBackground(String... query) {
       ArrayList<Contact> contacts = getContactsFrom(getCursor(query[0]));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: contacts_service
 description: A Flutter plugin to retrieve and manage contacts on Android and iOS devices.
-version: 0.0.8
+version: 0.0.9
 author: Clovis Nicolas <clovisnicolas0@gmail.com>
 homepage: https://github.com/clovisnicolas/flutter_contacts
 


### PR DESCRIPTION
Removed `getContactResult` field from `ContactsServicePlugin`. This is needed because `onMethodCall` spawns an async task for every call. If this state is kept in `getContactResult`, the second call will fail because the `success` method will be called on the wrong instance.

The error, described in issue #21 typically happens when searching contacts. (e.g in an autocomplete field)