### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ On iOS, make sure to set `NSContactsUsageDescription` in the `Info.plist` file
 
 To check and request user permission to access contacts, I recommend using the following plugin: [flutter_simple_permissions](https://github.com/AppleEducate/flutter_simple_permissions)
 
+If you do not request user permission or have it granted, the application will fail. For testing purposes, you can manually set the permissions for your test app in Settings for your app on the device that you are using. For Android, go to "Settings" - "Apps" - select your test app - "Permissions" - then turn "on" the slider for contacts. 
+
 ## Example
 
 ``` dart


### PR DESCRIPTION
Add a clarification about how to manually enable permissions for users who are not using flutter simple permissions

Since the flutter error message is misleading (says you need to add user permissions lines to code)