### PR TITLE
Fixed build errors for Android & iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,32 +1,38 @@
 PODS:
-  - contacts_service (0.0.1):
+  - contacts_service (0.2.1):
     - Flutter
   - Flutter (1.0.0)
   - path_provider (0.0.1):
+    - Flutter
+  - permission_handler (2.2.0):
     - Flutter
   - share_extend (0.0.1):
     - Flutter
 
 DEPENDENCIES:
-  - contacts_service (from `/Users/developer/Github/flutter_contacts/ios`)
-  - Flutter (from `/Users/developer/flutter/bin/cache/artifacts/engine/ios`)
-  - path_provider (from `/Users/developer/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider-0.4.1/ios`)
-  - share_extend (from `/Users/developer/flutter/.pub-cache/hosted/pub.dartlang.org/share_extend-1.0.3/ios`)
+  - contacts_service (from `/Users/Development/FlutterProjects/contacts_service/master/flutter_contacts/ios`)
+  - Flutter (from `/Users/Development/flutter/bin/cache/artifacts/engine/ios`)
+  - "path_provider (from `/Users/Development/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider-0.5.0+1/ios`)"
+  - permission_handler (from `/Users/Development/flutter/.pub-cache/hosted/pub.dartlang.org/permission_handler-2.2.0/ios`)
+  - share_extend (from `/Users/Development/flutter/.pub-cache/hosted/pub.dartlang.org/share_extend-1.0.4/ios`)
 
 EXTERNAL SOURCES:
   contacts_service:
-    :path: "/Users/developer/Github/flutter_contacts/ios"
+    :path: "/Users/Development/FlutterProjects/contacts_service/master/flutter_contacts/ios"
   Flutter:
-    :path: "/Users/developer/flutter/bin/cache/artifacts/engine/ios"
+    :path: "/Users/Development/flutter/bin/cache/artifacts/engine/ios"
   path_provider:
-    :path: "/Users/developer/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider-0.4.1/ios"
+    :path: "/Users/Development/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider-0.5.0+1/ios"
+  permission_handler:
+    :path: "/Users/Development/flutter/.pub-cache/hosted/pub.dartlang.org/permission_handler-2.2.0/ios"
   share_extend:
-    :path: "/Users/developer/flutter/.pub-cache/hosted/pub.dartlang.org/share_extend-1.0.3/ios"
+    :path: "/Users/Development/flutter/.pub-cache/hosted/pub.dartlang.org/share_extend-1.0.4/ios"
 
 SPEC CHECKSUMS:
-  contacts_service: 3d584b5457e56df4e68608a765b0dfc88b80479c
+  contacts_service: 8b4231a6c81d4a3d1be440105f113158111ff2ff
   Flutter: 9d0fac939486c9aba2809b7982dfdbb47a7b0296
   path_provider: 09407919825bfe3c2deae39453b7a5b44f467873
+  permission_handler: 0b2a5acb642be1ad2406adc31d0cda567b8b01e2
   share_extend: 5c61436f8ad534ac10471cf80c929cc16b226196
 
 PODFILE CHECKSUM: b3f98f39b16cc0a18e5ea9ecbe5cfbc88c2ad26a

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -41,7 +40,6 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		376C65EDF2BBF4969C4BF795 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
@@ -92,7 +90,6 @@
 			children = (
 				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
-				2D5378251FAA1A9400D5DBA9 /* flutter_assets */,
 				9740EEBA1CF902C7004384FC /* Flutter.framework */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -209,7 +206,6 @@
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				9740EEB51CF90195004384FC /* Generated.xcconfig in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */,
 				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
@@ -258,9 +254,10 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../../../../../flutter/bin/cache/artifacts/engine/ios/Flutter.framework",
+				"${PODS_ROOT}/../../../../../../../flutter/bin/cache/artifacts/engine/ios/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/contacts_service/contacts_service.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider/path_provider.framework",
+				"${BUILT_PRODUCTS_DIR}/permission_handler/permission_handler.framework",
 				"${BUILT_PRODUCTS_DIR}/share_extend/share_extend.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -268,6 +265,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/contacts_service.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/permission_handler.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/share_extend.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
**Doctor summary:**

[✓] Flutter (Channel stable, v1.2.1, on Mac OS X, locale en-US)
[✓] Android toolchain - develop for Android devices (Android SDK version 28.0.3)
[✓] iOS toolchain - develop for iOS devices (Xcode 10.1)

**Android bug:**
```
FAILURE: Build failed with an exception.
* What went wrong:
A problem occurred configuring project ':permission_handler'.
```
Solution
```
1. rm example/android/gradlew example/android/gradlew.bat
2. re-run example app flutter run command
```

**iOS bug:**
```
Deleting the example app on the Apple device, then performing a new build, will sometimes produce the following error:

Xcode build done.                                           38.6s
Oops; flutter has exited unexpectedly.
Sending crash report to Google.
## exception
ProcessException: ProcessException: Process "/usr/bin/xcrun" exited abnormally:
An error was encountered processing the command (domain=IXUserPresentableErrorDomain, code=1):
This app could not be installed at this time.
```
Solution
```
1. Re-run the flutter run command
```
_Note: flutter clean was tested but does not resolve the issue. This is a reproducible bug._